### PR TITLE
Remove hirak/prestissimo dependency 

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -460,8 +460,6 @@ step_php() {
     curl -sS https://getcomposer.org/installer | php
     mv composer.phar /usr/local/bin/composer
 
-    runuser -l $user -c $'composer global require hirak/prestissimo'
-
     service php7.4-fpm restart
   fi
 }


### PR DESCRIPTION
composer 2.0 are out, and don't need prestissimo anymore
and throw error:
```Package hirak/prestissimo at version has a PHP requirement incompatible with your PHP version, PHP extensions and Composer version```